### PR TITLE
removing unused PanelManager

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,6 @@ define(function (require, exports, module) {
     // get access to needed singletons
     var CommandManager     = brackets.getModule("command/CommandManager"),
         EditorManager      = brackets.getModule("editor/EditorManager"),
-        PanelManager       = brackets.getModule("view/PanelManager"),
         Menus              = brackets.getModule("command/Menus"),
         ExtensionUtils     = brackets.getModule("utils/ExtensionUtils"),
         PreferencesManager = brackets.getModule("preferences/PreferencesManager"),


### PR DESCRIPTION
This fixes #7. It looks like `PanelManager` no longer loads. However, it is also not used anywhere in the plugin. It now works in Brackets 1.12.