### PR TITLE
only triggering diagram on type 2 strings that also start with /

### DIFF
--- a/main.js
+++ b/main.js
@@ -184,7 +184,9 @@ define(function (require, exports, module) {
                     // get token under cursor
                     regex = editor._codeMirror.getTokenAt(editor.getCursorPos());
 
-                    if (regex && regex.type === "string-2") {
+                    // regular expressions will be a type 2 string, and always start
+                    // with a forward slash
+                    if (regex && regex.type === "string-2" && /^\//.test(regex.string)) {
                         regex = regex.string;
                     } else {
                         regex = '';


### PR DESCRIPTION
This fixes #6.

Template strings are also a type 2 string, so it was triggering the diagram. However, regular expressions will always start with `/`, naturally, so we can safely ignore any other type 2 string.